### PR TITLE
Fix go.mod file and update README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,16 @@ Run with `docker run -p 8080:8080 gcr.io/as-a-service-dev/memegen`
 * `top`:  text to add at the top of the image
 * `bottom`:  text to add at the bottom of the image
 
-## Running the server locally
+## Setting up container image
+** Must enable Cloud Build API: Navigate to the "APIs & Services" section in the left sidebar.
+Click on the "Library" tab.
+Search for "Cloud Build API" ** 
 
+## Run in terminal
+* gcloud builds submit . --tag  gcr.io/your-project-id/your-image-name:latest --project your-image-name
+
+## Running the server locally
+## cloudshell_open --repo_url "https://github.com/as-a-service/meme.git" --page "shell"
 * Build with `docker build . -t memegen`
 * Start with `docker run -p 8080:8080 memegen`
 * Open in your browser at `http://localhost:8080/`
@@ -23,3 +31,4 @@ Run with `docker run -p 8080:8080 gcr.io/as-a-service-dev/memegen`
 The following container image always reflects the latest version of the `master` branch of this repo: `gcr.io/as-a-service-dev/memegen`
 
 ![Cloud Build](https://badger-l7zawt5jsq-uw.a.run.app/build/status?project=as-a-service-dev&id=fdd11a9f-8f5d-46f2-974c-0ab041c02b30)
+

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,10 @@
-module "https://github.com/steren/memegen"
+module github.com/steren/memegen
+
+go 1.22.1
+
+require github.com/fogleman/gg v1.2.0
 
 require (
-	github.com/fogleman/gg v1.2.0
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	golang.org/x/image v0.0.0-20190227222117-0694c2d4d067 // indirect
 )


### PR DESCRIPTION
Hey there! 👋

I've been working with the memegen project and noticed an issue with the go.mod file that was causing problems with importing the required module. I dug into it and found a solution that I think will help make the setup process smoother for everyone.

This pull request makes two changes: 
1.  Updated the go.mod file: 
- Fixed the module path format by changing it from "https://github.com/steren/memegen" to github.com/steren/memegen.
- `go mod tidy` did the rest of setting Go version
2. Added setup instructions to the README.md file:
- Included a helpful note about enabling the Cloud Build API and provided steps to do so.
- Added the command to run in the terminal for submitting the build.

With these changes, the go.mod file should now correctly import the required module, making the setup process easier for everyone following this tutorial in 2024!

Thanks for maintaining this awesome project! I hope this contribution helps improve the developer experience. Let me know if you have any questions or suggestions.

Cheers! 😊


